### PR TITLE
Fix a warning under Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ setup(
     author_email='zttt183525594@gmail.com',
     description='Youtube music provider for FeelUOwn music player',
     keywords=['feeluown', 'plugin', 'youtube'],
-    classifiers=(
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
-    ),
+    ],
     install_requires=[
         'feeluown>=3.4',
         'requests',


### PR DESCRIPTION
`Warning: 'classifiers' should be a list, got type 'tuple'`

Related issue: https://bugs.python.org/issue19610